### PR TITLE
add -Wconversion to compile options

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -1,6 +1,6 @@
 function(enable_warnings TARGET SCOPE)
     if (APPLE OR UNIX)
-        target_compile_options(${TARGET} ${SCOPE} -Wall -Wextra -pedantic)
+        target_compile_options(${TARGET} ${SCOPE} -Wall -Wextra -Wpedantic -Wconversion)
     elseif(MSVC)
         target_compile_options(${TARGET} ${SCOPE} /W4)
     endif()


### PR DESCRIPTION
I don't know all the implications of this change. Some code fragments won't compile any more, I assume. But I think this is important and I just recently had to be informed by a Windows build that I am converting int to unsigned int, because on Mac, clang did not complain.