### PR TITLE
Disable msvc warning 4201

### DIFF
--- a/include/shield/on.h
+++ b/include/shield/on.h
@@ -48,6 +48,7 @@
 #pragma warning(disable : 4100)
 #pragma warning(disable : 4127)
 #pragma warning(disable : 4191)
+#pragma warning(disable : 4201)
 #pragma warning(disable : 4242)
 #pragma warning(disable : 4244)
 #pragma warning(disable : 4250)


### PR DESCRIPTION
Disable msvc 4201 nonstandard extension used: nameless struct/union